### PR TITLE
fixing airtable and centering tables

### DIFF
--- a/js/airtable.js
+++ b/js/airtable.js
@@ -79,14 +79,14 @@ try {
   for (const result of results){
     for (const foreignKey of result.toolkit_resources_ID){
       const newInfo = await base('Toolkit Resources').find(foreignKey)
-        result.toolkit_resources.push = {
+        result.toolkit_resources.push({
           "tool_item" : newInfo.fields['Toolkit Item'],
           "url" : newInfo.fields['URL'],
           "author_institution" : newInfo.fields['Author or Institution'],
           "blindspot_quote" : newInfo.fields['Blindspot Quote'],
           "type_resource" : newInfo.fields['Type of Resource'],
           "year" : newInfo.fields['Year'],
-        };
+        });
       };
     };
 

--- a/themes/ptTheme/layouts/_default/single.html
+++ b/themes/ptTheme/layouts/_default/single.html
@@ -15,10 +15,10 @@
             {{ $file := .Params.datafile}}
             {{ $index := .Params.index }}
             {{ if $file }}
-              {{ $blindspots := getJSON $file }} 
-              {{ $blindspot := index $blindspots $index }}   
-              <h1 class="post-title" itemprop="name headline">{{ $blindspot.blindspot_name }}</h1>
-              <span>*phase*</span>
+                {{ $blindspots := getJSON $file }} 
+                {{ $blindspot := index $blindspots $index }}   
+                <h1 class="post-title" itemprop="name headline">{{ $blindspot.blindspot_name }}</h1>
+                <span>*phase*</span>
             {{ end }}
           </header>
 
@@ -27,92 +27,92 @@
             {{ $file := .Params.datafile}}
             {{ $index := .Params.index }}
             {{ if $file }}
-              {{ $blindspots := getJSON $file }} 
-              {{ $blindspot := index $blindspots $index }}  
-              <table>
-                <thead>
-                  <tr>
-                    <th>Researcher perspective</th>
-                    <th>Practitioner perspective</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <td>{{ $blindspot.academic_perspective }}</td>
-                    <td>{{ $blindspot.practitioner_perspective }}</td>
-                  </tr>
-                </tbody>
-              </table>
-              <table>
-                <thead>
-                  <tr>
-                    <th text-align="center">Convergence Point</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <td>{{ $blindspot.convergence_opportunities }}</td>
-                  </tr>
-                </tbody>
-              </table>
-              <br />
-              <table style="margin-left: auto; margin-right: auto;">
-                <thead>
-                  <tr>
-                    <th>Questions Researchers Can Ask</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {{ range $blindspot.DGQ }}
+                {{ $blindspots := getJSON $file }} 
+                {{ $blindspot := index $blindspots $index }}  
+                <table style="text-align: center; margin-left: auto; margin-right: auto;">
+                  <thead>
                     <tr>
-                      {{ if eq .perspective "Researcher Question" }}
-                        <td>{{ index .question  }}</td>
-                      {{ end }}
+                      <th>Researcher perspective</th>
+                      <th>Practitioner perspective</th>
                     </tr>
-                  {{ end }}
-                </tbody>
-              </table>
-              <br />
-              <table style="margin-left: auto; margin-right: auto;">
-                <thead>
-                  <tr>
-                    <th>Questions Practitioners Can Ask</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {{ range $blindspot.DGQ }}
+                  </thead>
+                  <tbody>
                     <tr>
-                      {{ if eq .perspective "Practitioner Question" }}
-                        <td>{{ .question  }}</td>
-                      {{ end }}
+                      <td>{{ $blindspot.academic_perspective }}</td>
+                      <td>{{ $blindspot.practitioner_perspective }}</td>
                     </tr>
-                  {{ end }}
-                </tbody>
-              </table>
-              <br />
-              <table style="margin-left: auto; margin-right: auto;">
-                <thead>
-                  <tr>
-                    <th>Questions Both Can Ask</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {{ range $blindspot.DGQ }}
+                  </tbody>
+                </table>
+                <table style="text-align: center; margin-left: auto; margin-right: auto;">
+                  <thead>
                     <tr>
-                      {{ if eq .perspective "Both" }}
-                        <td>{{ .question  }}</td>
-                      {{ end }}
+                      <th text-align="center">Convergence Point</th>
                     </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td>{{ $blindspot.convergence_opportunities }}</td>
+                    </tr>
+                  </tbody>
+                </table>
+                <br />
+                <table style="margin-left: auto; margin-right: auto;">
+                  <thead>
+                    <tr>
+                      <th>Questions Researchers Can Ask</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {{ range $blindspot.DGQ }}
+                      <tr>
+                        {{ if eq .perspective "Researcher Question" }}
+                          <td>{{ index .question  }}</td>
+                        {{ end }}
+                      </tr>
+                    {{ end }}
+                  </tbody>
+                </table>
+                <br />
+                <table style="margin-left: auto; margin-right: auto;">
+                  <thead>
+                    <tr>
+                      <th>Questions Practitioners Can Ask</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {{ range $blindspot.DGQ }}
+                      <tr>
+                        {{ if eq .perspective "Practitioner Question" }}
+                          <td>{{ .question  }}</td>
+                        {{ end }}
+                      </tr>
+                    {{ end }}
+                  </tbody>
+                </table>
+                <br />
+                <table style="margin-left: auto; margin-right: auto;">
+                  <thead>
+                    <tr>
+                      <th>Questions Both Can Ask</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {{ range $blindspot.DGQ }}
+                      <tr>
+                        {{ if eq .perspective "Both" }}
+                          <td>{{ .question  }}</td>
+                        {{ end }}
+                      </tr>
+                    {{ end }}
+                  </tbody>
+                </table>
+                <br />
+                <b>Timeline Tools</b><br />
+                {{ range $blindspot.toolkit_resources }}
+                  {{ if .tool_item }}
+                    - {{ .tool_item }} <a href=" {{ .url }}"> {{ .author_institution }} {{ .year }}, {{ .blindspot_quote }}</a> <br />
                   {{ end }}
-                </tbody>
-              </table>
-              <br />
-              <b>Timeline Tools</b><br />
-              {{ range $blindspot.toolkit_resources }}
-                {{ if .tool_item }}
-                  - {{ .tool_item }} <a href=" {{ .url }}"> {{ .author_institution }} {{ .year }}, {{ .blindspot_quote }}</a> <br />
                 {{ end }}
-              {{ end }}
             {{ end }}
           </div>
 


### PR DESCRIPTION
-Noticed and issue with airtable.js.  The 'push' for toolkit data had incorrect syntax and this data was not being gathered properly.
-Updated list.html so the tables would display centered.  This helps the page look consistent even when data is not present or smaller.