### PR TITLE
added placeholder for about & faq pages

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -5,5 +5,3 @@ date: "2020–012–09"
 menu: "main"
 draft: "false"
 ---
-
-Hello PT! 

--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -1,0 +1,5 @@
+---
+name: About Page
+---
+
+Content coming

--- a/content/faq/_index.md
+++ b/content/faq/_index.md
@@ -1,0 +1,5 @@
+---
+name: FAQ Page
+---
+
+Content coming

--- a/themes/ptTheme/layouts/about/list.html
+++ b/themes/ptTheme/layouts/about/list.html
@@ -1,0 +1,4 @@
+<h1>{{ .Params.name }}</h1>
+
+<h2>About page placeholder</h2>
+{{ .Content }}

--- a/themes/ptTheme/layouts/faq/list.html
+++ b/themes/ptTheme/layouts/faq/list.html
@@ -1,0 +1,4 @@
+<h1>{{ .Params.name }}</h1>
+
+<h2>FAQ page placeholder</h2>
+{{ .Content }}

--- a/themes/ptTheme/layouts/partials/header.html
+++ b/themes/ptTheme/layouts/partials/header.html
@@ -27,10 +27,10 @@
         <div class="collapse navbar-collapse" id="navbarCollapse">
           <ul class="navbar-nav ml-auto">
             <li class="nav-item">
-              <a class="nav-link" style="color:darkgray" href="./faq.html">FAQ</a>
+              <a class="nav-link" style="color:darkgray" href="./faq" target="_blank">FAQ</a>
             </li>
             <li class="nav-item">
-              <a class="nav-link" style="color: darkgray;" href="./files/EVIDENCE_GAP_MAP_USER_MANUAL.pdf" target="_blank">About</a>
+              <a class="nav-link" style="color: darkgray;" href="./about" target="_blank">About</a>
             </li>
           </ul>
         </div>


### PR DESCRIPTION
Adding infrastructure for 'about' and 'faq' pages to be ready when content is available. 