### PR TITLE
fixed url for single.html page

### DIFF
--- a/themes/ptTheme/layouts/partials/header.html
+++ b/themes/ptTheme/layouts/partials/header.html
@@ -27,10 +27,10 @@
         <div class="collapse navbar-collapse" id="navbarCollapse">
           <ul class="navbar-nav ml-auto">
             <li class="nav-item">
-              <a class="nav-link" style="color:darkgray" href="./faq" target="_blank">FAQ</a>
+              <a class="nav-link" style="color:darkgray" href="{{ .Site.BaseURL }}/faq" target="_blank">FAQ</a>
             </li>
             <li class="nav-item">
-              <a class="nav-link" style="color: darkgray;" href="./about" target="_blank">About</a>
+              <a class="nav-link" style="color: darkgray;" href="{{ .Site.BaseURL }}/about" target="_blank">About</a>
             </li>
           </ul>
         </div>


### PR DESCRIPTION
Single.html had incorrect link for 'about' and 'faq' pages.  Updated the link to be more universal and static to work across list.html and single.html.